### PR TITLE
refactor: 重複投稿の事前チェックを行っている場合は、随時既存投稿のチェックを行わないようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ bin/esa-sync-importer [options] <source> <destination>
   * `-w`, `--wip` : WIPで投稿する
   * `-n`, `--dry-run` : ドライラン
   * `-t`, `--team` : esa.ioのチーム名(必須)
-  * `-i=`, `--ignore-existing` : すでに同じタイトルの記事がある場合はスキップ
+  * `-i`, `--ignore-existing` : すでに同じタイトルの記事がある場合はスキップ
 * source : インポートするファイルのあるディレクトリ
 * destination : インポート先のesa.ioのチーム名とカテゴリ名を指定する    
   `team-name/category-name` のように指定する。    

--- a/usecases/esa-usecase.js
+++ b/usecases/esa-usecase.js
@@ -109,6 +109,7 @@ class EsaUsecase {
 
       await this.updateFile({ postId, name, body, team });
       return
+      await this.waitRateLimit({ response });
     }
 
     // 記事を新規投稿する


### PR DESCRIPTION
* [refactor: 重複投稿の事前チェックを行っている場合は、随時既存投稿のチェックを行わないようにする](https://github.com/interrupt-inc/esa-sync-importer/commit/b326be966b63b6c30d4c660ddd66bfa57e751ed5)
* [fix: レートリミットの待機の追加](https://github.com/interrupt-inc/esa-sync-importer/commit/232f9cf7da8c38cb8e35e50a63df7d3d21af32bf)